### PR TITLE
Extend to .NET Core 2.1 and add NuGet publishing information.

### DIFF
--- a/src/BlurSharp.Drawing/BlurSharp.Drawing.csproj
+++ b/src/BlurSharp.Drawing/BlurSharp.Drawing.csproj
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <Version>0.0.1-alpha.1</Version>
+    <PackageProjectUrl>https://github.com/crozone/BlurSharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/crozone/BlurSharp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>blurhash image preview compression encoding</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Authors>Ryan Crosby</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/BlurSharp.Drawing/BlurSharp.Drawing.csproj
+++ b/src/BlurSharp.Drawing/BlurSharp.Drawing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/BlurSharp/BlurSharp.csproj
+++ b/src/BlurSharp/BlurSharp.csproj
@@ -1,7 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <Version>0.0.1-alpha.1</Version>
+    <PackageProjectUrl>https://github.com/crozone/BlurSharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/crozone/BlurSharp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>blurhash image preview compression encoding</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Authors>Ryan Crosby</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BlurSharp/BlurSharp.csproj
+++ b/src/BlurSharp/BlurSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`netcoreapp2.1` supports this library (the `Span<>` type), but doesn't implement `netstandard2.1`.  So I added both targets.

https://docs.microsoft.com/en-us/dotnet/standard/net-standard

I also added the NuGet publishing information to get you closer to when you are going to publish.